### PR TITLE
Fixed malloc cast warning in gh_stringWithFormat:arguments:

### DIFF
--- a/Classes/GHNSString+Utils.m
+++ b/Classes/GHNSString+Utils.m
@@ -41,8 +41,8 @@
 @implementation NSString(GHUtils)
 
 + (id)gh_stringWithFormat:(NSString *)format arguments:(NSArray *)arguments {
-  char *argList = (char *)malloc(sizeof(NSString *) * [arguments count]);
-  [arguments getObjects:(id *)argList];
+  id *argList = calloc(arguments.count, sizeof(id));
+  [arguments getObjects:argList range:NSMakeRange(0, arguments.count)];
   NSString *result = [[[NSString alloc] initWithFormat:format arguments:(void *)argList] autorelease];
   free(argList);
   return result;


### PR DESCRIPTION
This code was allocating a dynamic C array of id and casting it to a char pointer. The static analyzer said:

> Result of 'malloc' is converted to a pointer of type 'char', which is incompatible with sizeof operand type 'NSString *'

I was a little confused, too, so I changed around some of the types and now the compiler, static analyzer, and I are happy.
