### PR TITLE
Update UILineBreakMode to NSLineBreakMode

### DIFF
--- a/Classes/iOS/GHNSString+UIKitUtils.h
+++ b/Classes/iOS/GHNSString+UIKitUtils.h
@@ -52,7 +52,7 @@ typedef NSUInteger GHNSStringAlignment;
  @param lineBreakMode Line break mode
  @param alignment Alignment
  */
-- (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font lineBreakMode:(UILineBreakMode)lineBreakMode 
+- (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font lineBreakMode:(NSLineBreakMode)lineBreakMode
             alignment:(GHNSStringAlignment)alignment;
 
 /*!
@@ -67,6 +67,6 @@ typedef NSUInteger GHNSStringAlignment;
  @param alignment Alignment
  */
 - (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font minFontSize:(CGFloat)minFontSize actualFontSize:(CGFloat *)actualFontSize 
-        lineBreakMode:(UILineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment;
+        lineBreakMode:(NSLineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment;
 
 @end

--- a/Classes/iOS/GHNSString+UIKitUtils.m
+++ b/Classes/iOS/GHNSString+UIKitUtils.m
@@ -31,7 +31,7 @@
 
 @implementation NSString(GHUIKitUtils)
 
-- (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font lineBreakMode:(UILineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment {
+- (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font lineBreakMode:(NSLineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment {
 	
 	CGSize size = [self sizeWithFont:font forWidth:rect.size.width lineBreakMode:lineBreakMode];
 	
@@ -52,7 +52,7 @@
 }
 
 - (void)gh_drawInRect:(CGRect)rect font:(UIFont *)font minFontSize:(CGFloat)minFontSize actualFontSize:(CGFloat *)actualFontSize 
-        lineBreakMode:(UILineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment {
+        lineBreakMode:(NSLineBreakMode)lineBreakMode alignment:(GHNSStringAlignment)alignment {
 	
   if (!actualFontSize) {
     CGFloat fontSize;


### PR DESCRIPTION
Some parameters in GHKit still use `UILineBreakMode`, which means that with stricter warnings you'll get a warning for passing an `NSLineBreakMode` value instead of the deprecated `UILineBreakMode` values.

This changes updates the uses of `UILineBreakMode` to `NSLineBreakMode`.
