### PR TITLE
Removed gh_parseTimeSinceEpoch:withDefault:offsetForTimeZone:

### DIFF
--- a/Classes/GHNSDate+Formatters.h
+++ b/Classes/GHNSDate+Formatters.h
@@ -79,16 +79,6 @@
 + (NSDate *)gh_parseTimeSinceEpoch:(id)timeSinceEpoch withDefault:(id)withDefault;
 
 /*!
- Parse time since epoch (1970) in seconds.
-
- @param timeSinceEpoch Seconds since Jan 1970 (epoch); An NSNumber or NSString (responds to doubleValue)
- @param withDefault If timeSinceEpoch is nil, returns this value
- @param timeZone If set, the returned Date will be offset from the supplied timestamp by the difference between timeZone and the system time zone
- @result NSDate or nil if timeSinceEpoch was nil
- */
-+ (NSDate *)gh_parseTimeSinceEpoch:(id)timeSinceEpoch withDefault:(id)withDefault offsetForTimeZone:(NSTimeZone *)timeZone;
-
-/*!
  Get date formatted for RFC822.
 
  @result The date string, like "Wed, 01 Mar 2006 12:00:00 -0400"

--- a/Classes/GHNSDate+Formatters.m
+++ b/Classes/GHNSDate+Formatters.m
@@ -65,7 +65,7 @@ static NSDateFormatter *gAscTimeDateFormatter = NULL;
 
 + (NSDate *)gh_parseTimeSinceEpoch:(id)timeSinceEpoch withDefault:(id)value {
   if (!timeSinceEpoch) return value;
-	return [NSDate dateWithTimeIntervalSince1970:[timeSinceEpoch doubleValue]];
+  return [NSDate dateWithTimeIntervalSince1970:[timeSinceEpoch doubleValue]];
 }
 
 - (NSString *)gh_formatRFC822 {

--- a/Classes/GHNSDate+Formatters.m
+++ b/Classes/GHNSDate+Formatters.m
@@ -64,22 +64,8 @@ static NSDateFormatter *gAscTimeDateFormatter = NULL;
 }
 
 + (NSDate *)gh_parseTimeSinceEpoch:(id)timeSinceEpoch withDefault:(id)value {
-  return [self gh_parseTimeSinceEpoch:timeSinceEpoch withDefault:value offsetForTimeZone:nil];
-}
-
-+ (NSDate *)gh_parseTimeSinceEpoch:(id)timeSinceEpoch withDefault:(id)value offsetForTimeZone:(NSTimeZone *)timeZone {
   if (!timeSinceEpoch) return value;
-	NSDate *normalDate = [NSDate dateWithTimeIntervalSince1970:[timeSinceEpoch doubleValue]];
-  if (!timeZone)
-    return normalDate;
-  NSTimeZone *localTimeZone = [NSTimeZone localTimeZone];
-  if ([localTimeZone isEqualToTimeZone:timeZone])
-    return normalDate;
-  // The following adapted from http://stackoverflow.com/questions/1081647/how-to-convert-time-to-the-timezone-of-the-iphone-device/1082179#1082179
-  NSInteger offset = [timeZone secondsFromGMTForDate:normalDate];
-  NSInteger localOffset = [localTimeZone secondsFromGMTForDate:normalDate];
-  NSTimeInterval difference = localOffset - offset;
-  return [[[NSDate alloc] initWithTimeInterval:difference sinceDate:normalDate] autorelease];
+	return [NSDate dateWithTimeIntervalSince1970:[timeSinceEpoch doubleValue]];
 }
 
 - (NSString *)gh_formatRFC822 {


### PR DESCRIPTION
NSDate is supposed to be timezone-agnostic. Any timezone info should be passed to an NSDateFormatter for display. Gonna remove this method to avoid the temptation to shift around dates.
