### PR TITLE
Patch ordinalization logic to account for compound locale identifiers.

### DIFF
--- a/Classes/GHNSNumber+Utils.m
+++ b/Classes/GHNSNumber+Utils.m
@@ -118,13 +118,13 @@
 // http://wiki.services.openoffice.org/wiki/Localized_AutoCorrection_of_Ordinal_Numbers_(1st_2nd)#French
 + (NSString *)gh_ordinalize:(NSInteger)value masculine:(BOOL)masculine {
   NSString *languageCode = [[NSLocale preferredLanguages] gh_firstObject];
-  if ([languageCode isEqual:@"en"]) {
+  if ([languageCode hasPrefix:@"en"]) {
     return [NSNumber gh_ordinalizeEn:value];
-  } else if ([languageCode isEqual:@"fr"]) {
+  } else if ([languageCode hasPrefix:@"fr"]) {
     return [NSNumber gh_ordinalizeFr:value masculine:masculine];
-  } else if ([languageCode isEqual:@"de"]) {
+  } else if ([languageCode hasPrefix:@"de"]) {
     return [NSNumber gh_ordinalizeDe:value masculine:masculine];
-  } else if ([languageCode isEqual:@"es"]) {
+  } else if ([languageCode hasPrefix:@"es"]) {
     return [NSNumber gh_ordinalizeEs:value masculine:masculine];
   }
   return [NSString stringWithFormat:@"%ld", (long)value];

--- a/GHKitYelpFork.podspec
+++ b/GHKitYelpFork.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "GHKitYelpFork"
-  s.version      = "1.1.1"
+  s.version      = "1.1.2"
   s.summary      = "The GHKit framework is a set of extensions and utilities for Mac OS X and iOS."
   s.homepage     = "http://github.com/Yelp/gh-kit"
   s.license      = "MIT"


### PR DESCRIPTION
This change allows GHKit to "ordinalize" for a superset of the originally-supported locale identifiers.

Examples of previously-supported identifiers: "en", "fr", "de", "es"
Examples of currently-supported identifiers: "en", "en-US", "fr", "fr-CA", etc.